### PR TITLE
Clean and fix

### DIFF
--- a/core/register/ghBernoulli.m
+++ b/core/register/ghBernoulli.m
@@ -1,13 +1,18 @@
 function [g, h, htype] = ghBernoulli(mu, f, c, varargin)
 % FORMAT [g, (h, htype)] = ghBernoulli(mu, f, c, (ga),
 %                                   ('loop', loop), ('par', par))
-% mu   - Reconsturcted probability template
+%
+% ** Required **
+% mu   - Reconstructed probability template.
 % f    - Observed image pushed in the template space.
 % c    - Pushed voxel count.
+% ** Optional **
 % ga   - Spatial gradients of the log-probability template.
+% ** Keyword arguments **
 % loop - Specify how to split data processing
-%        ('component', 'slice' or 'none' [default])
+%        ('component', 'slice' or 'none' [default: auto])
 % par  - If true, parallelise processing [default: false]
+% ** Output **
 % g    - Gradient
 % h    - Hessian
 % htype - Shape of the hessian ('diagonal', 'symtensor')
@@ -211,7 +216,7 @@ function [g, h] = onMemory(mu, f, c, gmu)
     
     g  = (c .* mu) - f;
     if ~isempty(gmu)
-        g = pointwise(gmu, g, 't');
+        g = -pointwise(gmu, g, 't');
     end
     if nargout > 1
         h  = c .* (mu .* (1 - mu)) + 1E-3; % Avoid null hessian

--- a/core/register/ghCategorical.m
+++ b/core/register/ghCategorical.m
@@ -168,19 +168,19 @@ function [g, h] = onMemory(mu, f, c, gmu)
     
     g  = bsxfun(@times, c, mu) - f;
     if ~isempty(gmu)
-        g = pointwise(gmu, g, 't');
+        g = -pointwise(gmu, g, 't');
     end
     if nargout > 1
         [ind, length] = symIndices(nc, 'n');
         h = zeros([lat length], 'like', g);
         % Diagonals of the tensors
         for k=1:nc
-            h(:,:,:,ind(k,k)) = c .* (  mu(:,:,:,k) - mu(:,:,:,k).^2 );
+            h(:,:,:,ind(k,k)) = -c .* ( mu(:,:,:,k).^2 - mu(:,:,:,k) );
         end
         % Upper/Lower part
         for l=1:nc
             for m=(l+1):nc
-                h(:,:,:,ind(l,m)) = - c .* mu(:,:,:,l) .* mu(:,:,:,m);
+                h(:,:,:,ind(l,m)) = -c .* mu(:,:,:,l) .* mu(:,:,:,m);
             end
         end
         if ~isempty(gmu)

--- a/core/register/ghLaplace.m
+++ b/core/register/ghLaplace.m
@@ -223,7 +223,7 @@ function [g, h] = onMemory(mu, f, c, b, gmu)
     g  = sign(bsxfun(@times, c, mu) - f);
     g  = bsxfun(@times, b, g);
     if ~isempty(gmu)
-        g = pointwise(gmu, g, 't');
+        g = -pointwise(gmu, g, 't');
     end
     if nargout > 1
         h = bsxfun(@times, b, c);

--- a/core/register/ghMatchingLatent.m
+++ b/core/register/ghMatchingLatent.m
@@ -135,7 +135,7 @@ function [g, h] = onMemory(model, mu, f, c, gmu, w, varargin)
     if nargout > 1
         [g, h, htype] = ghMatchingVel(model, mu, f, c, varargin{:});
     else
-        g = gradHessMatchingVel(model, mu, f, c, varargin{:});
+        g = ghMatchingVel(model, mu, f, c, varargin{:});
     end
     clear mu f c
 

--- a/core/register/ghNormal.m
+++ b/core/register/ghNormal.m
@@ -223,7 +223,7 @@ function [g, h] = onMemory(mu, f, c, s, gmu)
     g  = (bsxfun(@times, c, mu) - f);
     g  = bsxfun(@times, s, g);
     if ~isempty(gmu)
-        g = pointwise(gmu, g, 't');
+        g = -pointwise(gmu, g, 't');
     end
     if nargout > 1
         h = bsxfun(@times, s, c);

--- a/core/register/ghPriorVel.m
+++ b/core/register/ghPriorVel.m
@@ -1,0 +1,38 @@
+function g = ghPriorVel(v, varargin)
+% FORMAT g = ghPriorVel(v, (vs), (prm))
+%
+% ** Required **
+% v   - Initial velocity
+% ** Optional **
+% vs  - Voxel size of the template lattice [1 1 1]
+% prm - Parameters of the L differential operator
+%       [0.0001 0.001 0.2 0.05 0.2]
+% ** Output **
+% g   - Gradient
+%
+% Gradient of the *negative* log-likelihood of the prior term for the
+% initial velocity (Lv).
+
+    % --- Parse inputs
+    p = inputParser;
+    p.FunctionName = 'ghPriorVel';
+    p.addRequired('v',         @checkarray);
+    p.addOptional('vs',        [1 1 1], @(X) length(X) == 3);
+    p.addOptional('prm',       [0.0001 0.001 0.2 0.05 0.2], @(X) length(X) == 5);
+    p.addParameter('output',   []);
+    p.addParameter('debug',    false,   @isscalar);
+    p.parse(v, varargin{:});
+    vs      = p.Results.vs;
+    prm     = p.Results.prm;
+    output  = p.Results.output;
+    debug   = p.Results.debug;
+    
+    if debug, fprintf('* ghPriorVel\n'); end;
+    
+    g = spm_diffeo('vel2mom', single(numeric(v)), [vs prm]);
+    
+    if ~isempty(output)
+        g = writeOnDisk(output, g, 'name', 'g');
+    end
+
+end

--- a/core/register/llLaplace.m
+++ b/core/register/llLaplace.m
@@ -1,82 +1,81 @@
 function ll = llLaplace(varargin)
-% FORMAT ll = llLaplace(('latent', hz), ('residual', hr), ('affine', hq))
+% FORMAT ll = llLaplace((H), (vs), (prm), ...)
 %
 % ** Keyword arguments **
-% hz - Hessian of the log-likelihood w.r.t. current Z.
-%        Its inverse is the covariance of Laplace approximation of 
-%        p(Z | F, Mu, W, R).
-% hr - Hessian of the log-likelihood w.r.t. current R.
-%        Its inverse is the covariance of Laplace approximation of 
-%        p(R | F, Mu, W, Z).
-% hq - Hessian of the log-likelihood w.r.t. current Q.
-%        Its inverse is the covariance of Laplace approximation of 
-%        p(q | F, Mu, W, Z).
+% H   - Hessian of the negative log-likelihood w.r.t. the latent variable.
+%       Its inverse is the covariance of Laplace approximation of 
+%       p(Z | F, THETA).
+%       If not a square matrix, it should be a (eventually symmetric)
+%       tensor field.
+% vs  - Voxel size of the lattice when part of the Hessian is made of L'L.
+% prm - Parameters of the differential operator when part of the Hessian is
+%       made of L'L.
 % ** Output **
-% ll - Parts of the log-likelihood which encompass Laplace approximation
-%        terms.
+% ll - Parts of the log-likelihood of a Laplace approximation.
 %
-% Parts of Laplace approximation of the posterior:
-% p(F|Mu) = int_{Z,R} p(F | Mu, Z, R) dZ dR
-%         = (2pi)^(-K*N*Q/2) |-H(R*,Z*,q*)|^(1/2) p(F | Mu, Z*, R*, q*) p(Z*) p(R*) p(q*)
-%         = (2pi)^(-K*N*Q/2) |-H(R*)|^(1/2) |-H(Z*)|^(1/2) |-H(Q*)|^(1/2) p(F | Mu, Z*, R*, q*) p(Z*) p(R*) p(q*)
-% where Z*, R*, q* define a mode of p(F|Mu,Z,R,Q) and H is the hessian of
-% respectively {R,Z,Q}, Z, R qnd Q around this mode.
-% This function thus returns:
-% ll = -0.5 * KNQ * log(2pi) + 0.5 * log(|-H(Z*)|) + 0.5 * log(|-H(R*)|) + 0.5 * log(|-H(q*)|)
+% This function returns parts of the log-likelihood of a zero-mean Gaussian 
+% of precision (i.e., inverse covariance) matrix H. It is used to compute
+% the log-likelihood of the Laplace approximation of a given posterior:
+% log p(z | F, THETA) = -N/2 log(2pi) - 1/2 log(|H|) - 1/2 z'Hz
+%
+% This function returns only -N/2 log(2pi) - 1/2 log(|H|). The matching 
+% part (- 1/2 z'Hz) can be computed with specfic functions 
+% (llMatchingNormal, llMatchingLaplace, ...)
 
     % --- Parse inputs
     p = inputParser;
     p.FunctionName = 'llLaplace';
-    p.addParameter('latent',    [], @checkarray);
-    p.addParameter('residual',  [], @checkarray);
-    p.addParameter('affine',    [], @checkarray);
+    p.addOptional('H',     [], @(X) size(X, 2) > 1 || length(X) > 2);
+    p.addOptional('vs',    [], @(X) size(X, 1) == 1 && length(X) == 3);
+    p.addOptional('prm',   [], @(X) size(X, 1) == 1 && length(X) == 5);
     p.addParameter('debug',  false, @isscalar);
     p.parse(varargin{:});
-    hz = p.Results.latent;
-    hr = p.Results.residual;
-    hq = p.Results.affine;
+    H     = p.Results.H;
+    vs    = p.Results.vs;
+    prm   = p.Results.prm;
+    debug = p.Results.debug;
     
-    if p.Results.debug, fprintf('* llLaplace\n'); end;
+    if debug, fprintf('* llLaplace\n'); end;
     
     ll = 0;
     
-    % --- Z part
-    if ~isempty(hz)
-        K  = size(hz, 1);
-        ll = ll - logDet(hz);
-        useZ = 1;
-    else
-        K = 1;
-        useZ = 0;
+    if ~isempty(H)
+        % --- Square matrix case
+        if length(size(H)) == 2 && size(H, 1) == size(H, 2)
+            N  = size(H, 1);
+            ll = N * log(2*pi) + logDet(H);
+            ll = -0.5 * ll;
+
+        % --- Symmetric tensor case
+        elseif length(size(H)) == 4
+            dim = [size(H) 1 1];
+            [~, N] = symIndices(dim(4));
+            N  = N * prod(dim(1:3));
+%             ll = N * log(2*pi) + logDetSymTensor(H);
+            ll = N * log(2*pi) + sumall(log(pointwise3(H, 'd')+eps('single')));
+            ll = -0.5 * ll;
+
+        % --- Full tensor case
+        elseif length(size(H)) == 5 && size(H, 4) == size(H, 5)
+            dim = [size(H) 1 1];
+            N   = prod(dim(1:4));
+%             ll  = N * log(2*pi) + logDetTensor(H);
+            ll  = N * log(2*pi) + sumall(log(pointwise3(H, 'd')));
+            ll  = -0.5 * ll;
+
+        else
+            error('Unrecognized Hessian form')
+        end
     end
     
-    % --- R part
-    if ~isempty(hr)
-        dim = [size(hr) 1 1 1];
-        N   = prod(dim(1:4));
-        ll  = ll - logDetSymTensor(hr);
-        useR = 1;
-    else
-        N = 1;
-        useR = 0;
+    % --- L'L part
+    if ~isempty(prm)
+        dim = [size(H) 1 1];
+        [~, ld] = spm_shoot_greens('kernel', dim(1:3), [vs prm]);
+        ll = ll - 0.5 * ld(1);
+        if isempty(H)
+            ll = ll - 0.5 * ld(2) * log(2*pi);
+        end
     end
-    
-    % --- Q part
-    if ~isempty(hq)
-        dim = [size(hq) 1 1 1];
-        Q   = prod(dim(1:4));
-        ll  = ll - logDet(hq);
-        useQ = 1;
-    else
-        Q = 1;
-        useQ = 0;
-    end
-    
-    % --- Common part
-    ll = ll * (-1)^(N*useR + K*useZ + Q*useQ);
-    ll = ll + N^useR * K^useZ * Q^useQ * log(2 * pi);
-    
-    % --- Common factor
-    ll = -0.5 * ll;
     
 end

--- a/core/register/precisionZ.m
+++ b/core/register/precisionZ.m
@@ -1,5 +1,5 @@
 function ww = precisionZ(w, varargin)
-% FORMAT ww = obj.precisionZ(w, (vs), (prm))
+% FORMAT ww = precisionZ(w, (vs), (prm))
 % w   - Principal subspace
 % vs  - Voxel size of the initial velocity lattice [1 1 1]
 % prm - Parameters of the L operator (see spm_diffeo)

--- a/scripts/pg_registration.m
+++ b/scripts/pg_registration.m
@@ -7,7 +7,7 @@ function opt = pg_registration(opt)
 % The input option structure (opt) should at least contain the fields:
 % fnames.f  / dat.f  - the target image (as a file or array)
 % fnames.mu / dat.mu - the template image (as a file or array)
-% fnames.w  / dat.w  - the principal sibspace (as a file or array)
+% fnames.w  / dat.w  - the principal subspace (as a file or array)
 %
 % The following parameters can be overriden by specifying them in the
 % input option structure:

--- a/scripts/pg_registration.m
+++ b/scripts/pg_registration.m
@@ -310,6 +310,8 @@ function opt = pg_registration(opt)
     end
     opt.dat.llz = llPriorAffine(opt.dat.z, opt.regz, 'debug', opt.debug);
     
+    opt.dat.savell = [];
+    
     % ---------------------------------------------------------------------
     %    Processing
     % ---------------------------------------------------------------------
@@ -332,6 +334,15 @@ function opt = pg_registration(opt)
         clear g h
         
         opt.dat.h = loadDiag(opt.dat.h); % Additional regularisation for robustness
+        
+        % Update full model likelihood (with Laplace approximation)
+        % ---------------------------------------------------------
+        
+        opt.dat.lllz = llLaplace(opt.dat.h, 'debug', opt.debug);
+        
+        [opt.dat.ll, opt.dat.savell] = plotLikelihood(opt.verbose, ...
+            opt.dat.savell, opt.dat.llm, ...
+            opt.dat.llz, opt.dat.lllz);
         
         % Compute ascent direction
         % ------------------------
@@ -375,11 +386,70 @@ function opt = pg_registration(opt)
         opt.dat.g = opt.dat.g + g;
         opt.dat.h = opt.dat.h + h;
         clear g h
+        
+        opt.dat.lllz = llLaplace(opt.dat.h, 'debug', opt.debug);
     end
+    [opt.dat.ll, opt.dat.savell] = plotLikelihood(opt.verbose, ...
+        opt.dat.savell, opt.dat.llm, ...
+        opt.dat.llz, opt.dat.lllz);
     
     
     % Warp template to image
     % ----------------------
     opt.dat.wmu = warp(opt.dat.ipsi, opt.dat.mu, opt.itrp, opt.bnd, ...
         'par', opt.par, 'output', opt.dat.wmu, 'debug', opt.debug);
+end
+
+function [ll, savell] = plotLikelihood(verbose, savell, varargin)
+    ll = 0;
+    llreg = 0;
+    llprec = 0;
+    llmatch = 0;
+    for i=1:numel(varargin)
+        if isempty(varargin{i})
+            ll = 0;
+            return;
+        end
+        ll = ll + varargin{i};
+        if i == 1
+            llmatch = varargin{i};
+        else
+            if mod(i-2, 2)
+                llreg = llreg + varargin{i};
+            else
+                llprec = llprec + varargin{i};
+            end
+        end
+    end
+    
+    if isempty(savell)
+        savell       = struct;
+        savell.ll    = [];
+        savell.match = [];
+        savell.reg   = [];
+        savell.prec  = [];
+    end
+    
+    savell.ll(end+1)    = ll;
+    savell.match(end+1) = llmatch;
+    savell.reg(end+1)   = llreg;
+    savell.prec(end+1)  = llprec;
+    x = (1:length(savell.ll))/3;
+    
+    if verbose
+        fprintf('LL = %f\n', ll);
+        subplot(2, 2, 1)
+        plot(x, savell.ll,    'b-')
+        title('Model log-likelihood')
+        subplot(2, 2, 2)
+        plot(x, savell.match, 'r-')
+        title('Model log-likelihood (matching)')
+        subplot(2, 2, 3)
+        plot(x, savell.reg,   'g-')
+        title('Model log-likelihood (regularisation)')
+        subplot(2, 2, 4)
+        plot(x, savell.prec,  'k-')
+        title('Model log-likelihood (precision)')
+        drawnow
+    end
 end

--- a/scripts/pgr_registration.m
+++ b/scripts/pgr_registration.m
@@ -8,7 +8,7 @@ function opt = pgr_registration(opt)
 % The input option structure (opt) should at least contain the fields:
 % fnames.f  / dat.f  - the target image (as a file or array)
 % fnames.mu / dat.mu - the template image (as a file or array)
-% fnames.w  / dat.w  - the principal sibspace (as a file or array)
+% fnames.w  / dat.w  - the principal subspace (as a file or array)
 %
 % The following parameters can be overriden by specifying them in the
 % input option structure:

--- a/scripts/pgr_registration.m
+++ b/scripts/pgr_registration.m
@@ -327,6 +327,13 @@ function opt = pgr_registration(opt)
             opt.prm, 'debug', opt.debug);
     end
     opt.dat.llz = llPriorAffine(opt.dat.z, opt.regz, 'debug', opt.debug);
+    opt.dat.llr = llPriorVelocity(opt.dat.r, ...
+        'vs', sqrt(sum(opt.dat.Mmu(1:3,1:3).^2)), ...
+        'prm', opt.prm, 'debug', opt.debug);
+    
+    opt.dat.lllz   = [];
+    opt.dat.lllr   = [];
+    opt.dat.savell = [];
     
     % ---------------------------------------------------------------------
     %    Processing
@@ -354,6 +361,16 @@ function opt = pgr_registration(opt)
         clear gz hz
         
         opt.dat.hz = loadDiag(opt.dat.hz); % Additional regularisation for robustness
+        
+        opt.dat.lllz = llLaplace(opt.dat.hz, 'debug', opt.debug);
+        
+        % Update full model likelihood (with Laplace approximation)
+        % ---------------------------------------------------------
+        
+        [opt.dat.ll, opt.dat.savell] = plotLikelihood(opt.verbose, ...
+            opt.dat.savell, opt.dat.llm, ...
+            opt.dat.llz, opt.dat.lllz, ...
+            opt.dat.llr, opt.dat.lllr);
         
         % Compute ascent direction
         % ------------------------
@@ -393,10 +410,28 @@ function opt = pgr_registration(opt)
             opt.dat.mu, opt.dat.pf, opt.dat.c, opt.dat.gmu, ...
             'loop', opt.loop, 'par', opt.par, 'debug', opt.debug);
         
+        opt.dat.gr = opt.dat.gr + ghPriorVel(opt.dat.r, ...
+            sqrt(sum(opt.dat.Mmu(1:3,1:3).^2)), opt.prm);
+        
+        if size(opt.dat.mu, 3) == 1
+            opt.dat.hr(:,:,:,3) = 1;
+        end
+        
+        opt.dat.lllr = llLaplace(opt.dat.hr, ...
+            sqrt(sum(opt.dat.Mmu(1:3,1:3).^2)), opt.prm, 'debug', opt.debug);
+        
         % Compute ascent direction
         % ------------------------
-        opt.dat.dr = spm_diffeo('fmg', single(opt.dat.hr), single(opt.dat.gr), ...
+        opt.dat.dr = -spm_diffeo('fmg', single(opt.dat.hr), single(opt.dat.gr), ...
             [sqrt(sum(opt.dat.Mmu(1:3,1:3).^2)) opt.prm 2 2]);
+        
+        % Update full model likelihood (with Laplace approximation)
+        % ---------------------------------------------------------
+        
+        [opt.dat.ll, opt.dat.savell] = plotLikelihood(opt.verbose, ...
+            opt.dat.savell, opt.dat.llm, ...
+            opt.dat.llz, opt.dat.lllz, ...
+            opt.dat.llr, opt.dat.lllr);
         
         % Line search
         % -----------
@@ -443,11 +478,84 @@ function opt = pgr_registration(opt)
         opt.dat.gz = opt.dat.gz + gz;
         opt.dat.hz = opt.dat.hz + hz;
         clear gz hz
+        
+        opt.dat.lllz = llLaplace(opt.dat.hz, 'debug', opt.debug);
+        
     end
+    if okr
+        [opt.dat.gr, opt.dat.hr] = ghMatchingVel(opt.model, ...
+            opt.dat.mu, opt.dat.pf, opt.dat.c, opt.dat.gmu, ...
+            'loop', opt.loop, 'par', opt.par, 'debug', opt.debug);
+        
+        if size(opt.dat.mu, 3) == 1
+            opt.dat.hr(:,:,:,3) = 1;
+        end
+        
+        opt.dat.lllr = llLaplace(opt.dat.hr, ...
+            sqrt(sum(opt.dat.Mmu(1:3,1:3).^2)), opt.prm, 'debug', opt.debug);
+    end
+    [opt.dat.ll, opt.dat.savell] = plotLikelihood(opt.verbose, ...
+        opt.dat.savell, opt.dat.llm, ...
+        opt.dat.llz, opt.dat.lllz, ...
+        opt.dat.llr, opt.dat.lllr);
     
     
     % Warp template to image
     % ----------------------
     opt.dat.wmu = warp(opt.dat.ipsi, opt.dat.mu, opt.itrp, opt.bnd, ...
         'par', opt.par, 'output', opt.dat.wmu, 'debug', opt.debug);
+end
+
+function [ll, savell] = plotLikelihood(verbose, savell, varargin)
+    ll = 0;
+    llreg = 0;
+    llprec = 0;
+    llmatch = 0;
+    for i=1:numel(varargin)
+        if isempty(varargin{i})
+            ll = 0;
+            return;
+        end
+        ll = ll + varargin{i};
+        if i == 1
+            llmatch = varargin{i};
+        else
+            if mod(i-2, 2)
+                llreg = llreg + varargin{i};
+            else
+                llprec = llprec + varargin{i};
+            end
+        end
+    end
+    
+    if isempty(savell)
+        savell       = struct;
+        savell.ll    = [];
+        savell.match = [];
+        savell.reg   = [];
+        savell.prec  = [];
+    end
+    
+    savell.ll(end+1)    = ll;
+    savell.match(end+1) = llmatch;
+    savell.reg(end+1)   = llreg;
+    savell.prec(end+1)  = llprec;
+    x = (1:length(savell.ll))/3;
+    
+    if verbose
+        fprintf('LL = %f\n', ll);
+        subplot(2, 2, 1)
+        plot(x, savell.ll,    'b-')
+        title('Model log-likelihood')
+        subplot(2, 2, 2)
+        plot(x, savell.match, 'r-')
+        title('Model log-likelihood (matching)')
+        subplot(2, 2, 3)
+        plot(x, savell.reg,   'g-')
+        title('Model log-likelihood (regularisation)')
+        subplot(2, 2, 4)
+        plot(x, savell.prec,  'k-')
+        title('Model log-likelihood (precision)')
+        drawnow
+    end
 end

--- a/scripts/pgra_registration.m
+++ b/scripts/pgra_registration.m
@@ -1,5 +1,5 @@
 function opt = pgra_registration(opt)
-% FORMAT opt = pgr_registration(opt)
+% FORMAT opt = pgra_registration(opt)
 %
 % Combines affine and diffeomorphic registration of a template towards
 % a target image, based on a "principal geodesic" model + a residual 
@@ -8,7 +8,7 @@ function opt = pgra_registration(opt)
 % The input option structure (opt) should at least contain the fields:
 % fnames.f  / dat.f  - the target image (as a file or array)
 % fnames.mu / dat.mu - the template image (as a file or array)
-% fnames.w  / dat.w  - the principal sibspace (as a file or array)
+% fnames.w  / dat.w  - the principal subspace (as a file or array)
 %
 % The following parameters can be overriden by specifying them in the
 % input option structure:

--- a/test/test_affine.m
+++ b/test/test_affine.m
@@ -1,0 +1,15 @@
+
+    opt             = struct;
+    opt.directory   = '/Users/balbasty/Desktop/model/output';
+    opt.fnames.a    = fullfile('/Users/balbasty/Desktop/model', 'IXIcrap_mu.nii');
+    opt.fnames.f    = fullfile('/Users/balbasty/Desktop/model/input', 'IXI002-Guys-0828-T1.img');
+    opt.model       = struct('name', 'categorical');
+    opt.debug       = false;
+    opt.gnit        = 20;
+    opt.affine_basis = affine_basis(12, '2d');
+%     opt.regq        = 1E5 * eye(6);
+    opt.happrox     = true;
+    opt.par = false;
+    
+    opt = affine_registration(opt);
+    

--- a/test/test_diffeo.m
+++ b/test/test_diffeo.m
@@ -1,0 +1,13 @@
+
+    opt             = struct;
+    opt.directory   = '/Users/balbasty/Desktop/model/output';
+    opt.fnames.a    = fullfile('/Users/balbasty/Desktop/model', 'IXIcrap_mu.nii');
+    opt.fnames.f    = fullfile('/Users/balbasty/Desktop/model/input', 'IXI002-Guys-0828-T1.img');
+    opt.model       = struct('name', 'categorical');
+    opt.prm         = s.v_settings;
+    opt.debug       = false;
+    opt.gnit        = 20;
+    opt.par         = false;
+
+    opt = diffeo_registration(opt);
+    

--- a/test/test_pg.m
+++ b/test/test_pg.m
@@ -1,0 +1,15 @@
+
+    opt             = struct;
+    opt.directory   = '/Users/balbasty/Desktop/model/output';
+    opt.fnames.a    = fullfile('/Users/balbasty/Desktop/model', 'IXIcrap_mu.nii');
+    opt.fnames.w    = fullfile('/Users/balbasty/Desktop/model', 'IXIcrap_Wv.nii');
+    opt.fnames.f    = fullfile('/Users/balbasty/Desktop/model/input', 'IXI002-Guys-0828-T1.img');
+    opt.model       = struct('name', 'categorical');
+    opt.prm         = s.v_settings;
+    opt.regz        = WWv;
+    opt.debug       = false;
+    opt.gnit        = 20;
+    opt.par         = false;
+
+    opt = pg_registration(opt);
+    

--- a/test/test_pgr.m
+++ b/test/test_pgr.m
@@ -1,0 +1,15 @@
+
+    opt             = struct;
+    opt.directory   = '/Users/balbasty/Desktop/model/output';
+    opt.fnames.a    = fullfile('/Users/balbasty/Desktop/model', 'IXIcrap_mu.nii');
+    opt.fnames.w    = fullfile('/Users/balbasty/Desktop/model', 'IXIcrap_Wv.nii');
+    opt.fnames.f    = fullfile('/Users/balbasty/Desktop/model/input', 'IXI002-Guys-0828-T1.img');
+    opt.model       = struct('name', 'categorical');
+    opt.prm         = s.v_settings;
+    opt.regz        = WWv;
+    opt.debug       = false;
+    opt.gnit        = 20;
+    opt.par         = false;
+
+    opt = pgr_registration(opt);
+    

--- a/test/test_pgra.m
+++ b/test/test_pgra.m
@@ -1,0 +1,16 @@
+
+    opt              = struct;
+    opt.directory    = '/Users/balbasty/Desktop/model/output';
+    opt.fnames.a     = fullfile('/Users/balbasty/Desktop/model', 'IXIcrap_mu.nii');
+    opt.fnames.w     = fullfile('/Users/balbasty/Desktop/model', 'IXIcrap_Wv.nii');
+    opt.fnames.f     = fullfile('/Users/balbasty/Desktop/model/input', 'IXI002-Guys-0828-T1.img');
+    opt.model        = struct('name', 'categorical');
+    opt.prm          = s.v_settings;
+    opt.regz         = WWv;
+    opt.gnit         = 20;
+    opt.par          = false;
+    opt.happrox      = true;
+    opt.affine_basis = affine_basis(12);
+
+    opt = pgra_registration(opt);
+    

--- a/utility-functions/affine_basis.m
+++ b/utility-functions/affine_basis.m
@@ -1,18 +1,23 @@
-function B = affine_basis(type)
-% FORMAT B = affine_basis(type)
+function B = affine_basis(type, flat)
+% FORMAT B = affine_basis(type, ('2d'))
 % type - * 'translation'
 %        * 'rotation'
 %        * 'rigid'      or 6
 %        * 'similitude' or 7
 %        * 'affine'     or 12 [default]
+% 
 % B    - 4x4xQ array.
 %
 % Returns a Lie algebra basis system encoding for one of the above
 % transformation types.
 
-    if nargin < 1
-        type = 'affine';
+    if nargin < 2
+        flat = '3d';
+        if nargin < 1
+            type = 'affine';
+        end
     end
+    flat = ischar(flat) && strcmpi(flat, '2d');
     if ~ischar(type)
         type = num2str(type);
     end
@@ -45,6 +50,18 @@ function B = affine_basis(type)
              0 0 0 0   1 0 0 0   0 1 0 0 ;
              0 0 0 0   0 0 0 0   0 0 0 0 ];
     
+    % --- Remove 3D basis if 2D
+    if flat
+        Bt = Bt(:,1:8);
+        Br = Br(:,1:4);
+        Bsim = [ 1 0 0 0 ;
+                 0 1 0 0 ;
+                 0 0 0 0 ;
+                 0 0 0 0 ];
+        Bscl = Bscl(:,1:8);
+        Bshr = Bshr(:,1:4);
+    end
+         
     % --- Build complete basis
     switch type
         case 'translation'

--- a/utility-functions/loadDiag.m
+++ b/utility-functions/loadDiag.m
@@ -1,8 +1,10 @@
 function m = loadDiag(m)
 % Additional regularisation in case a matrix is singular
 
+    factor = 1e-7;
     while rcond(m) < 1e-5
-        m = m + 1e-7 * max(diag(m)) * eye(size(m));
+        m = m + factor * max(diag(m)) * eye(size(m));
+        factor = 10 * factor;
     end
 
 end


### PR DESCRIPTION
Registration scripts (i.e., equivalent to PGFit) seem to work now.

Attached: a qualitative comparison between PG registration (right) and PG + residual field (left).
(Middle top: Target image ; Middle bottom: Undeformed template)

<img width="1680" alt="pg_vs_pg r" src="https://user-images.githubusercontent.com/7803834/30595240-89b9e65c-9d48-11e7-8345-416514793128.png">

(Precision and regularisation are inverted in the plot, it is fixed by now)